### PR TITLE
Update for mongoid 7.1

### DIFF
--- a/spec/cancancan/model_adapters/mongoid_adapter_spec.rb
+++ b/spec/cancancan/model_adapters/mongoid_adapter_spec.rb
@@ -51,13 +51,24 @@ RSpec.describe CanCan::ModelAdapters::MongoidAdapter do
       expect(MongoidProject.accessible_by(@ability, :read).to_a).to eq([])
     end
 
-    it 'returns the correct records based on the defined ability' do
-      @ability.can :read, MongoidProject, title: 'Sir'
-      sir = MongoidProject.create(title: 'Sir')
-      MongoidProject.create(title: 'Lord')
-      MongoidProject.create(title: 'Dude')
+    context 'when records based on the defined ability' do
+      let!(:sir) { MongoidProject.create(title: 'Sir') }
 
-      expect(MongoidProject.accessible_by(@ability, :read).to_a).to eq([sir])
+      before do
+        @ability.can :read, MongoidProject, title: 'Sir'
+        MongoidProject.create(title: 'Lord')
+        MongoidProject.create(title: 'Dude')
+      end
+
+      it 'returns the correct records' do
+        expect(MongoidProject.accessible_by(@ability, :read).to_a).to eq([sir])
+      end
+
+      context 'when model has scope' do
+        it 'returns empty array' do
+          expect(MongoidProject.where(title: 'Lord').accessible_by(@ability, :read).to_a).to eq([])
+        end
+      end
     end
 
     it 'returns the correct records when a mix of can and cannot rules in defined ability' do


### PR DESCRIPTION
Since version 7.1, Mongoid changes `.or` behavior as same as in Rails ([PR](https://github.com/mongodb/mongoid/pull/4614))
So, code like this `Band.where(name: 1).or(name: 2)` converted to`{"$or"=>[{"name"=>"1"}, {"name"=>"2"}]}`.
We use `.or` for rules. This PR fixes the problem