### PR TITLE
Use $nor for joining cannot rules

### DIFF
--- a/spec/cancancan/model_adapters/mongoid_adapter_spec.rb
+++ b/spec/cancancan/model_adapters/mongoid_adapter_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe CanCan::ModelAdapters::MongoidAdapter do
     end
 
     it 'returns the correct records when a mix of can and cannot rules in defined ability' do
-      @ability.can :manage, MongoidProject, title: 'Sir'
-      @ability.cannot :destroy, MongoidProject
+      @ability.can :manage, MongoidProject
+      @ability.cannot :destroy, MongoidProject, title: { '$in' => %w[Lord Dude] }
 
       sir = MongoidProject.create(title: 'Sir')
       MongoidProject.create(title: 'Lord')


### PR DESCRIPTION
Previously this gem used a series of `'$ne'` operators for cannot rules. I have changed it to put then all inside a `$nor` block. This has the advantage that it works with more complex nested behaviors, such as `"$nor" => [{ name: { "$in" => ["Bob", "Jane"] }]`

Also includes some refactoring which makes it cleaner / easier to read.

As a result, this PR also changes the behavior of one spec which I think was incorrect previously:

```ruby
    # ORIGINAL spec
    it 'returns the correct records when a mix of can and cannot rules in defined ability' do
      @ability.can :manage, MongoidProject, title: 'Sir'
      @ability.cannot :destroy, MongoidProject

      sir = MongoidProject.create(title: 'Sir')
      MongoidProject.create(title: 'Lord')
      MongoidProject.create(title: 'Dude')

      expect(MongoidProject.accessible_by(@ability, :destroy).to_a).to eq([sir])  #=> I think should be []
    end
```

Here I think it should actually be no results, i.e. `[]`, because the .cannot rule should take precedence over the .can. I think this makes much more sense from a security standpoint, etc.

I have changed it to:

```ruby
    # NEW spec
    it 'returns the correct records when a mix of can and cannot rules in defined ability' do
      @ability.can :manage, MongoidProject
      @ability.cannot :destroy, MongoidProject, title: { '$in' => %w[Lord Dude] }

      sir = MongoidProject.create(title: 'Sir')
      MongoidProject.create(title: 'Lord')
      MongoidProject.create(title: 'Dude')

      expect(MongoidProject.accessible_by(@ability, :destroy).to_a).to eq([sir])
    end
```